### PR TITLE
feat: add credential provider holder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1852,6 +1852,10 @@ project(':s3shell-kafka-sdk') {
   checkstyle {
     configProperties = checkstyleConfigProperties("import-control-automq.xml")
   }
+
+  dependencies {
+    compileOnly libs.awsSdkAuth
+  }
 }
 
 project(':tools') {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -133,7 +133,8 @@ versions += [
   s3stream: "0.17.0-SNAPSHOT",
   opentelemetry: "1.32.0",
   opentelemetryAlpha: "1.32.0-alpha",
-  oshi: "6.4.7"
+  oshi: "6.4.7",
+  awsSdkAuth:"2.20.127",
 ]
 libs += [
   activation: "javax.activation:activation:$versions.activation",
@@ -231,6 +232,7 @@ libs += [
   commonMath3: "org.apache.commons:commons-math3:$versions.commonMath3",
   nettyHttp2: "io.netty:netty-codec-http2:$versions.netty",
   s3stream: "com.automq.elasticstream:s3stream:$versions.s3stream",
+  awsSdkAuth: "software.amazon.awssdk:auth:$versions.awsSdkAuth",
   opentelemetryJava8: "io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8:$versions.opentelemetryAlpha",
   opentelemetryOshi: "io.opentelemetry.instrumentation:opentelemetry-oshi:$versions.opentelemetryAlpha",
   opentelemetrySdk: "io.opentelemetry:opentelemetry-sdk:$versions.opentelemetry",

--- a/s3shell-kafka-sdk/src/main/java/com/automq/s3shell/sdk/auth/CredentialsProviderHolder.java
+++ b/s3shell-kafka-sdk/src/main/java/com/automq/s3shell/sdk/auth/CredentialsProviderHolder.java
@@ -19,14 +19,24 @@ package com.automq.s3shell.sdk.auth;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 public class CredentialsProviderHolder {
-    // This is a multi-cloud aware and auth-method-aware credentials provider. Invoker just use it directly.
-    private static AwsCredentialsProvider awsCredentialsProvider;
 
-    public static void create(AwsCredentialsProvider awsCredentialsProvider) {
-        CredentialsProviderHolder.awsCredentialsProvider = awsCredentialsProvider;
+    //global singleton credential provider
+    private static volatile AwsCredentialsProvider awsCredentialsProvider;
+
+    private CredentialsProviderHolder() {
     }
 
     public static AwsCredentialsProvider getAwsCredentialsProvider() {
+        if (awsCredentialsProvider == null) {
+            throw new IllegalStateException("AwsCredentialsProvider has not been initialized");
+        }
         return awsCredentialsProvider;
+    }
+
+    public static synchronized void create(AwsCredentialsProvider newAwsCredentialsProvider) {
+        if (awsCredentialsProvider != null) {
+            throw new IllegalStateException("AwsCredentialsProvider is already initialized");
+        }
+        awsCredentialsProvider = newAwsCredentialsProvider;
     }
 }

--- a/s3shell-kafka-sdk/src/main/java/com/automq/s3shell/sdk/auth/CredentialsProviderHolder.java
+++ b/s3shell-kafka-sdk/src/main/java/com/automq/s3shell/sdk/auth/CredentialsProviderHolder.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.automq.s3shell.sdk.auth;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+public class CredentialsProviderHolder {
+    // This is a multi-cloud aware and auth-method-aware credentials provider. Invoker just use it directly.
+    private static AwsCredentialsProvider awsCredentialsProvider;
+
+    public static void create(AwsCredentialsProvider awsCredentialsProvider) {
+        CredentialsProviderHolder.awsCredentialsProvider = awsCredentialsProvider;
+    }
+
+    public static AwsCredentialsProvider getAwsCredentialsProvider() {
+        return awsCredentialsProvider;
+    }
+}


### PR DESCRIPTION
Credential provider holder offer a global singleton AwsCredentialProvider instance. This holder help invokers to shield the difference between multi-cloud and auth-type.