### PR TITLE
fix(core): use partition metrics time as broker time

### DIFF
--- a/core/src/main/java/kafka/autobalancer/LoadRetriever.java
+++ b/core/src/main/java/kafka/autobalancer/LoadRetriever.java
@@ -417,6 +417,7 @@ public class LoadRetriever implements BrokerStatusListener {
                 clusterModel.updateTopicPartitionMetrics(partitionMetrics.brokerId(),
                         new TopicPartition(partitionMetrics.topic(), partitionMetrics.partition()),
                         partitionMetrics.getMetricValueMap(), partitionMetrics.time());
+                clusterModel.updateBrokerMetrics(partitionMetrics.brokerId(), new HashMap<>(), partitionMetrics.time());
                 break;
             default:
                 logger.error("Not supported metrics version {}", metrics.metricType());

--- a/core/src/main/java/kafka/autobalancer/model/ClusterModel.java
+++ b/core/src/main/java/kafka/autobalancer/model/ClusterModel.java
@@ -71,8 +71,9 @@ public class ClusterModel {
             long now = System.currentTimeMillis();
             for (Map.Entry<Integer, BrokerUpdater> entry : brokerMap.entrySet()) {
                 int brokerId = entry.getKey();
-                BrokerUpdater.Broker broker = (BrokerUpdater.Broker) entry.getValue().get();
+                BrokerUpdater.Broker broker = (BrokerUpdater.Broker) entry.getValue().get(now - maxToleratedMetricsDelay);
                 if (broker == null) {
+                    logger.warn("Broker {} metrics is out of sync, will be ignored in this round", brokerId);
                     continue;
                 }
                 if (excludedBrokerIds.contains(brokerId)) {


### PR DESCRIPTION
to prevent broker timestamp out-of-sync