### PR TITLE
fix(e2e): add consumer api timeout to 90s in hard bounce tests

### DIFF
--- a/tests/kafkatest/tests/core/group_mode_transactions_test.py
+++ b/tests/kafkatest/tests/core/group_mode_transactions_test.py
@@ -113,7 +113,8 @@ class GroupModeTransactionsTest(Test):
             self.kafka.await_no_under_replicated_partitions()
 
     def create_and_start_message_copier(self, input_topic, output_topic, transactional_id,
-                                        producer_block_timeout_ms, transaction_timeout):
+                                        producer_block_timeout_ms, transaction_timeout,
+                                        consumer_default_api_timeout_ms):
         message_copier = TransactionalMessageCopier(
             context=self.test_context,
             num_nodes=1,
@@ -128,7 +129,8 @@ class GroupModeTransactionsTest(Test):
             transaction_timeout=transaction_timeout,
             use_group_metadata=True,
             group_mode=True,
-            producer_block_timeout_ms=producer_block_timeout_ms
+            producer_block_timeout_ms=producer_block_timeout_ms,
+            consumer_default_api_timeout_ms=consumer_default_api_timeout_ms
         )
         message_copier.start()
         wait_until(lambda: message_copier.alive(message_copier.nodes[0]),
@@ -148,7 +150,7 @@ class GroupModeTransactionsTest(Test):
                 copier.restart(clean_shutdown)
 
     def create_and_start_copiers(self, input_topic, output_topic, num_copiers, producer_block_timeout_ms,
-                                 transaction_timeout):
+                                 transaction_timeout, consumer_default_api_timeout_ms):
         copiers = []
         for i in range(0, num_copiers):
             copiers.append(self.create_and_start_message_copier(
@@ -156,7 +158,8 @@ class GroupModeTransactionsTest(Test):
                 output_topic=output_topic,
                 transactional_id="copier-" + str(i),
                 producer_block_timeout_ms=producer_block_timeout_ms,
-                transaction_timeout=transaction_timeout
+                transaction_timeout=transaction_timeout,
+                consumer_default_api_timeout_ms=consumer_default_api_timeout_ms
             ))
         return copiers
 
@@ -233,16 +236,19 @@ class GroupModeTransactionsTest(Test):
         It returns the concurrently consumed messages.
         """
         producer_block_timeout_ms = None
+        consumer_default_api_timeout_ms = None
         transaction_timeout = self.transaction_timeout
         if failure_mode != "clean_bounce" and bounce_target == "brokers":
             # change from the default 60s to 90s to wait for broker recovery
             producer_block_timeout_ms = 90000
             transaction_timeout = 90000
+            consumer_default_api_timeout_ms = 90000
         copiers = self.create_and_start_copiers(input_topic=input_topic,
                                                 output_topic=output_topic,
                                                 num_copiers=num_copiers,
                                                 producer_block_timeout_ms=producer_block_timeout_ms,
-                                                transaction_timeout=transaction_timeout)
+                                                transaction_timeout=transaction_timeout,
+                                                consumer_default_api_timeout_ms=consumer_default_api_timeout_ms)
         concurrent_consumer = self.start_consumer(output_topic,
                                                   group_id="concurrent_consumer")
         clean_shutdown = False

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -182,6 +182,15 @@ public class TransactionalMessageCopier {
                 .dest("useGroupMetadata")
                 .help("Whether to use the new transactional commit API with group metadata");
 
+        parser.addArgument("--consumer-default-api-timeout-ms")
+                .action(store())
+                .required(false)
+                .setDefault(60000)
+                .type(Integer.class)
+                .metavar("CONSUMER-DEFAULT-API-TIMEOUT-MS")
+                .dest("consumerDefaultApiTimeoutMs")
+                .help("The default API timeout in milliseconds for the consumer.");
+
         return parser;
     }
 
@@ -224,6 +233,7 @@ public class TransactionalMessageCopier {
                 "org.apache.kafka.common.serialization.StringDeserializer");
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
                 "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, parsedArgs.getInt("consumerDefaultApiTimeoutMs"));
 
         return new KafkaConsumer<>(props);
     }
@@ -407,7 +417,7 @@ public class TransactionalMessageCopier {
                     } catch (ProducerFencedException e) {
                         throw new KafkaException(String.format("The transactional.id %s has been claimed by another process", transactionalId), e);
                     } catch (KafkaException e) {
-                        log.debug("Aborting transaction after catching exception", e);
+                        log.error("Aborting transaction after catching exception", e);
                         abortTransactionAndResetPosition(producer, consumer);
                     }
                 }


### PR DESCRIPTION
close #802 