### PR TITLE
fix(pr-827): fix release `PooledMemoryRecords` twice

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -451,12 +451,7 @@ public class KafkaChannel implements AutoCloseable {
             return 0;
 
         midWrite = true;
-        try {
-            return send.writeTo(transportLayer);
-        } catch (IOException e) {
-            send.release();
-            throw e;
-        }
+        return send.writeTo(transportLayer);
     }
 
     /**


### PR DESCRIPTION
fix #827 