### PR TITLE
chore: support release tgz file in workflow

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -29,6 +29,26 @@ jobs:
       - name: Build TarGz
         run: |
           ./gradlew -Pprefix=automq-${{ github.ref_name }}_ --build-cache --refresh-dependencies clean releaseTarGz
+          mkdir -p core/build/distributions/latest
+          for file in core/build/distributions/automq-*.tgz; do
+              if [[ ! "$file" =~ site-docs ]]; then
+                  echo "Find latest tgz file: $file"
+                  cp "$file" core/build/distributions/latest/automq-kafka-latest.tgz
+                  break
+              fi
+          done
+
+      - uses: jakejarvis/s3-sync-action@master
+        name: s3-upload-latest
+        with:
+          args: --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET:  automq-download-center
+          AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_CN_PROD_AK }}
+          AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_CN_PROD_SK }}
+          AWS_REGION: 'cn-northwest-1'
+          SOURCE_DIR: 'core/build/distributions/latest'
+          DEST_DIR: 'automq-for-kafka/tgz/latest'
 
       - name: GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Upload released tgz file to AutoMQ download center. After uploaded user can use the following command to download the latest open source AutoMQ tgz file.

```
curl -LO https://download.automq.com/automq-for-kafka/tgz/latest/automq-kafka-latest.tgz
```